### PR TITLE
feat: Tag/ShopTag スキーマ確立 + ShopTag 重複防止 unique 制約を追加

### DIFF
--- a/frontend/prisma/migrations/20260310000001_add_shoptag_unique/migration.sql
+++ b/frontend/prisma/migrations/20260310000001_add_shoptag_unique/migration.sql
@@ -1,0 +1,3 @@
+-- AddUniqueConstraint: ShopTag(shopId, tagId) の組み合わせは一意
+-- 同一店舗に同じタグが重複登録されることを防ぐ
+CREATE UNIQUE INDEX IF NOT EXISTS "ShopTag_shopId_tagId_key" ON "ShopTag"("shopId", "tagId");

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -77,6 +77,8 @@ model ShopTag {
 
   shop Shop @relation(fields: [shopId], references: [id], onDelete: Cascade)
   tag  Tag  @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([shopId, tagId])
 }
 
 model UserShop {


### PR DESCRIPTION
## 概要

Issue #13「Tag / ShopTag テーブルを Prisma スキーマに追加する」の対応。

Tag・ShopTag モデル自体は PR #23 でスキーマへの追加とマイグレーションを実施済みですが、
データ整合性のための `@@unique([shopId, tagId])` 制約が不足していたため追加します。

## 変更内容

### schema.prisma

```prisma
model ShopTag {
  ...
  @@unique([shopId, tagId])   ← 追加
}
```

同一店舗への同一タグの重複登録を DB レベルで防止します。

### マイグレーション（20260310000001_add_shoptag_unique）

```sql
CREATE UNIQUE INDEX IF NOT EXISTS "ShopTag_shopId_tagId_key"
  ON "ShopTag"("shopId", "tagId");
```

`IF NOT EXISTS` により、既存データがある環境でも安全に適用できます。

## Issue #13 チェックリスト

- [x] `schema.prisma` に `Tag` / `ShopTag` モデルを追加（PR #23 で完了）
- [x] マイグレーションファイルを生成（既存データを保持する形で）（PR #23 で完了）
- [x] Prismaのリレーション定義（Shop ↔ ShopTag ↔ Tag）を追加（PR #23 で完了）
- [x] **ShopTag に `@@unique([shopId, tagId])` 制約を追加**（このPR）

## 型チェック

```
npx tsc --noEmit → エラー 0件 ✅
```

## Closes

- #13 Tag / ShopTag テーブルをPrismaスキーマに追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)