### PR TITLE
feat: ページのローディング状態（loading.tsx）を追加する (#17)

### DIFF
--- a/frontend/src/app/favorite/loading.tsx
+++ b/frontend/src/app/favorite/loading.tsx
@@ -1,0 +1,21 @@
+import { AppLayout } from '@/components/layout/AppLayout'
+
+export default function Loading() {
+    return (
+        <AppLayout>
+            <main className="min-h-screen px-4 pt-6 pb-24 sm:px-6 lg:px-10">
+                <div className="mx-auto w-full max-w-md space-y-5 sm:max-w-lg md:max-w-2xl lg:max-w-4xl">
+                    {/* 検索欄スケルトン */}
+                    <div className="h-12 rounded-full bg-gray-200 animate-pulse" />
+
+                    {/* カードスケルトン */}
+                    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                        {[...Array(8)].map((_, i) => (
+                            <div key={i} className="h-40 rounded-xl bg-gray-200 animate-pulse" />
+                        ))}
+                    </div>
+                </div>
+            </main>
+        </AppLayout>
+    )
+}

--- a/frontend/src/app/map/loading.tsx
+++ b/frontend/src/app/map/loading.tsx
@@ -1,0 +1,14 @@
+import { AppLayout } from '@/components/layout/AppLayout'
+
+export default function Loading() {
+    return (
+        <AppLayout>
+            <main className="flex h-screen flex-col px-4 pb-24 pt-6 sm:px-6 lg:px-10">
+                <div className="mx-auto flex w-full max-w-md flex-1 flex-col sm:max-w-lg md:max-w-2xl lg:max-w-4xl">
+                    <div className="mb-4 h-8 w-24 rounded-lg bg-gray-200 animate-pulse" />
+                    <div className="relative mb-4 flex-1 rounded-2xl bg-gray-200 animate-pulse" />
+                </div>
+            </main>
+        </AppLayout>
+    )
+}

--- a/frontend/src/app/shops/[id]/loading.tsx
+++ b/frontend/src/app/shops/[id]/loading.tsx
@@ -1,0 +1,31 @@
+import { AppLayout } from '@/components/layout/AppLayout'
+
+export default function Loading() {
+    return (
+        <AppLayout>
+            <div className="pb-40 px-4">
+                <div className="mx-auto w-full max-w-2xl space-y-6">
+                    {/* ヘッダースケルトン */}
+                    <div className="h-10 w-10 rounded-full bg-gray-200 animate-pulse" />
+
+                    {/* 写真スケルトン */}
+                    <div className="h-56 rounded-2xl bg-gray-200 animate-pulse" />
+
+                    {/* 店名・ステータススケルトン */}
+                    <div className="space-y-2">
+                        <div className="flex items-start justify-between gap-4">
+                            <div className="h-8 w-48 rounded-lg bg-gray-200 animate-pulse" />
+                            <div className="h-6 w-20 rounded-full bg-gray-200 animate-pulse" />
+                        </div>
+                        <div className="h-4 w-32 rounded bg-gray-200 animate-pulse" />
+                    </div>
+
+                    {/* メモ・タグ・地図スケルトン */}
+                    <div className="h-24 rounded-xl bg-gray-200 animate-pulse" />
+                    <div className="h-16 rounded-xl bg-gray-200 animate-pulse" />
+                    <div className="h-48 rounded-xl bg-gray-200 animate-pulse" />
+                </div>
+            </div>
+        </AppLayout>
+    )
+}

--- a/frontend/src/app/shops/loading.tsx
+++ b/frontend/src/app/shops/loading.tsx
@@ -1,0 +1,28 @@
+import { AppLayout } from '@/components/layout/AppLayout'
+
+export default function Loading() {
+    return (
+        <AppLayout>
+            <main className="min-h-screen px-4 pt-6 pb-24 sm:px-6 lg:px-10">
+                <div className="mx-auto w-full max-w-md space-y-5 sm:max-w-lg md:max-w-2xl lg:max-w-4xl">
+                    {/* 検索欄スケルトン */}
+                    <div className="h-12 rounded-full bg-gray-200 animate-pulse" />
+
+                    {/* タブスケルトン */}
+                    <div className="flex gap-2">
+                        <div className="h-8 w-20 rounded-full bg-gray-200 animate-pulse" />
+                        <div className="h-8 w-20 rounded-full bg-gray-200 animate-pulse" />
+                        <div className="h-8 w-20 rounded-full bg-gray-200 animate-pulse" />
+                    </div>
+
+                    {/* カードスケルトン */}
+                    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                        {[...Array(8)].map((_, i) => (
+                            <div key={i} className="h-40 rounded-xl bg-gray-200 animate-pulse" />
+                        ))}
+                    </div>
+                </div>
+            </main>
+        </AppLayout>
+    )
+}


### PR DESCRIPTION
## 概要
issue #17 の対応。Server Components でデータ取得中に空白になる問題を解消するため、各ルートに `loading.tsx` を追加。

## 変更内容
| ファイル | スケルトン内容 |
|---|---|
| `app/shops/loading.tsx` | 検索欄・タブ・カードグリッド（8枚） |
| `app/shops/[id]/loading.tsx` | 写真・店名・ステータス・メモ・タグ・地図 |
| `app/favorite/loading.tsx` | 検索欄・カードグリッド（8枚） |
| `app/map/loading.tsx` | マップエリア全体 |

## テスト確認項目
- [ ] `/shops` アクセス時にスケルトンが表示されること
- [ ] `/shops/[id]` アクセス時にスケルトンが表示されること
- [ ] `/favorite` アクセス時にスケルトンが表示されること
- [ ] `/map` アクセス時にスケルトンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)