### PR TITLE
feat: Server Action のエラーハンドリングを統一する (#18)

### DIFF
--- a/frontend/src/app/actions/create-manual-shop.ts
+++ b/frontend/src/app/actions/create-manual-shop.ts
@@ -4,11 +4,15 @@ import { prisma } from '@/lib/prisma'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
+import type { ActionResult } from '@/lib/action-result'
 
-export async function createManualShop(formData: FormData) {
+export async function createManualShop(
+  _prevState: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
   // 認証チェック
   const session = await auth()
-  if (!session?.user?.id) throw new Error('Unauthorized')
+  if (!session?.user?.id) return { success: false, error: '認証が必要です' }
   const userId = session.user.id
 
   // バリデーション
@@ -16,8 +20,8 @@ export async function createManualShop(formData: FormData) {
   const address = formData.get('address') as string
   const memo = (formData.get('memo') as string) || null
 
-  if (!name?.trim()) throw new Error('Name is required')
-  if (!address?.trim()) throw new Error('Address is required')
+  if (!name?.trim()) return { success: false, error: '店名を入力してください' }
+  if (!address?.trim()) return { success: false, error: '住所を入力してください' }
 
   // Google Geocoding API で緯度経度を取得（失敗しても登録は続行）
   let lat: number | null = null
@@ -51,29 +55,33 @@ export async function createManualShop(formData: FormData) {
 
   const tags = formData.getAll('tags[]') as string[]
 
-  await prisma.$transaction(async (tx) => {
-    // 手動登録のため source='manual'、placeId は null
-    const shop = await tx.shop.create({
-      data: { name, address, lat, lng, source: 'manual' },
-    })
-
-    // ユーザーとお店を紐づける（初期ステータスは WANT）
-    await tx.userShop.create({
-      data: { userId, shopId: shop.id, status: 'WANT', memo },
-    })
-
-    // タグを登録（スパム防止のため最大5つまで）
-    for (const tagName of tags.slice(0, 5)) {
-      const tag = await tx.tag.upsert({
-        where: { name: tagName },
-        create: { name: tagName },
-        update: {},
+  try {
+    await prisma.$transaction(async (tx) => {
+      // 手動登録のため source='manual'、placeId は null
+      const shop = await tx.shop.create({
+        data: { name, address, lat, lng, source: 'manual' },
       })
-      await tx.shopTag.create({
-        data: { shopId: shop.id, tagId: tag.id },
+
+      // ユーザーとお店を紐づける（初期ステータスは WANT）
+      await tx.userShop.create({
+        data: { userId, shopId: shop.id, status: 'WANT', memo },
       })
-    }
-  })
+
+      // タグを登録（スパム防止のため最大5つまで）
+      for (const tagName of tags.slice(0, 5)) {
+        const tag = await tx.tag.upsert({
+          where: { name: tagName },
+          create: { name: tagName },
+          update: {},
+        })
+        await tx.shopTag.create({
+          data: { shopId: shop.id, tagId: tag.id },
+        })
+      }
+    })
+  } catch {
+    return { success: false, error: '登録に失敗しました' }
+  }
 
   revalidatePath('/shops')
   redirect('/shops')

--- a/frontend/src/app/actions/create-shop.ts
+++ b/frontend/src/app/actions/create-shop.ts
@@ -6,16 +6,20 @@ import { redirect } from 'next/navigation'
 import { writeFile, mkdir } from 'fs/promises'
 import { randomUUID } from 'crypto'
 import path from 'path'
+import type { ActionResult } from '@/lib/action-result'
 
-export async function createShop(formData: FormData) {
+export async function createShop(
+  _prevState: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
   // 認証チェック
   const session = await auth()
-  if (!session?.user?.id) throw new Error('Unauthorized')
+  if (!session?.user?.id) return { success: false, error: '認証が必要です' }
   const userId = session.user.id
 
   // バリデーション
   const name = formData.get('name') as string
-  if (!name?.trim()) throw new Error('Name is required')
+  if (!name?.trim()) return { success: false, error: '店名を入力してください' }
 
   const memo = (formData.get('memo') as string) || null
   const placeId = (formData.get('placeId') as string) || null
@@ -24,38 +28,46 @@ export async function createShop(formData: FormData) {
   const lng = formData.get('lng') ? parseFloat(formData.get('lng') as string) : null
   const tags = formData.getAll('tags[]') as string[]
 
-  // Shop・UserShop・Tag・ShopTag をトランザクションで登録
-  const { shopId } = await prisma.$transaction(async (tx) => {
-    // placeId が指定されていれば既存 Shop を再利用、なければ新規作成
-    let shop = placeId
-      ? await tx.shop.findFirst({ where: { placeId } })
-      : null
+  let shopId: string
 
-    if (!shop) {
-      shop = await tx.shop.create({
-        data: { name, address, lat, lng, placeId },
+  try {
+    // Shop・UserShop・Tag・ShopTag をトランザクションで登録
+    const result = await prisma.$transaction(async (tx) => {
+      // placeId が指定されていれば既存 Shop を再利用、なければ新規作成
+      let shop = placeId
+        ? await tx.shop.findFirst({ where: { placeId } })
+        : null
+
+      if (!shop) {
+        shop = await tx.shop.create({
+          data: { name, address, lat, lng, placeId },
+        })
+      }
+
+      // ユーザーとお店を紐づける（初期ステータスは WANT）
+      await tx.userShop.create({
+        data: { userId, shopId: shop.id, status: 'WANT', memo },
       })
-    }
 
-    // ユーザーとお店を紐づける（初期ステータスは WANT）
-    await tx.userShop.create({
-      data: { userId, shopId: shop.id, status: 'WANT', memo },
+      // タグを upsert して ShopTag を登録（Tag.name に @unique があるため upsert 可能）
+      for (const tagName of tags) {
+        const tag = await tx.tag.upsert({
+          where: { name: tagName },
+          create: { name: tagName },
+          update: {},
+        })
+        await tx.shopTag.create({
+          data: { shopId: shop.id, tagId: tag.id },
+        })
+      }
+
+      return { shopId: shop.id }
     })
 
-    // タグを upsert して ShopTag を登録（Tag.name に @unique があるため upsert 可能）
-    for (const tagName of tags) {
-      const tag = await tx.tag.upsert({
-        where: { name: tagName },
-        create: { name: tagName },
-        update: {},
-      })
-      await tx.shopTag.create({
-        data: { shopId: shop.id, tagId: tag.id },
-      })
-    }
-
-    return { shopId: shop.id }
-  })
+    shopId = result.shopId
+  } catch {
+    return { success: false, error: '登録に失敗しました' }
+  }
 
   // 写真のアップロード（ファイルシステム操作はトランザクション外で実行）
   // TODO: Issue #21 で S3 等のクラウドストレージへ移行予定

--- a/frontend/src/app/actions/delete-shop.ts
+++ b/frontend/src/app/actions/delete-shop.ts
@@ -2,24 +2,28 @@
 
 import { prisma } from '@/lib/prisma'
 import { auth } from '@/lib/auth'
-import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
+import type { ActionResult } from '@/lib/action-result'
 
-export async function deleteShop(shopId: string) {
+export async function deleteShop(shopId: string): Promise<ActionResult> {
   const session = await auth()
-  if (!session?.user?.id) throw new Error('Unauthorized')
+  if (!session?.user?.id) return { success: false, error: '認証が必要です' }
   const userId = session.user.id
 
-  // 自分の UserShop レコードのみ削除（お店本体は共有データのため残す）
-  const result = await prisma.userShop.deleteMany({
-    where: { shopId, userId },
-  })
+  try {
+    // 自分の UserShop レコードのみ削除（お店本体は共有データのため残す）
+    const result = await prisma.userShop.deleteMany({
+      where: { shopId, userId },
+    })
 
-  if (result.count === 0) {
-    throw new Error('削除対象が見つからないか、権限がありません')
+    if (result.count === 0) {
+      return { success: false, error: '削除対象が見つからないか、権限がありません' }
+    }
+
+    revalidatePath('/shops')
+    revalidatePath('/map')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '削除に失敗しました' }
   }
-
-  revalidatePath('/shops')
-  revalidatePath('/map')
-  redirect('/shops')
 }

--- a/frontend/src/app/actions/sign-up.ts
+++ b/frontend/src/app/actions/sign-up.ts
@@ -6,6 +6,7 @@ import { signIn } from '@/lib/auth'
 import { query } from '@/lib/db.server'
 import { randomUUID } from 'crypto'
 import type { QueryResultRow } from 'pg'
+import type { ActionResult } from '@/lib/action-result'
 
 type SignUpInput = {
   email: string
@@ -17,76 +18,52 @@ type UserIdRow = QueryResultRow & {
   id: string
 }
 
-export async function signUp(input: SignUpInput) {
+export async function signUp(input: SignUpInput): Promise<ActionResult> {
   const { email, password, name } = input
 
-  try {
-    console.log('🟡 signUp start (SQL)', { email })
+  console.log('🟡 signUp start (SQL)', { email })
 
-    // ① 既存ユーザーの確認（同じメールアドレスが既に登録されていないかチェック）
-    const existingUsers = await query<UserIdRow>(
-      `
-      SELECT id
-      FROM "User"
-      WHERE email = $1
-      LIMIT 1
-      `,
+  // ① 既存ユーザーの確認（同じメールアドレスが既に登録されていないかチェック）
+  let existingUsers: UserIdRow[]
+  try {
+    existingUsers = await query<UserIdRow>(
+      `SELECT id FROM "User" WHERE email = $1 LIMIT 1`,
       [email]
     )
+  } catch {
+    return { success: false, error: '登録に失敗しました' }
+  }
 
-    if (existingUsers.length > 0) {
-      throw new Error('USER_ALREADY_EXISTS')
-    }
+  if (existingUsers.length > 0) {
+    return { success: false, error: 'このメールアドレスは既に登録されています' }
+  }
 
-    // ② データベースに保存する前にパスワードをハッシュ化（暗号化）して安全にする
-    const hashedPassword = await bcrypt.hash(password, 10)
+  // ② パスワードをハッシュ化
+  const hashedPassword = await bcrypt.hash(password, 10)
+  const userId = randomUUID()
+  const now = new Date()
 
-    const userId = randomUUID()
-    const now = new Date()
-
+  try {
     // ③ "User" テーブルに新しいユーザーレコードを作成
     await query(
-      `
-      INSERT INTO "User" (
-        id,
-        email,
-        "passwordHash",
-        "createdAt",
-        "updatedAt"
-      )
-      VALUES ($1, $2, $3, $4, $5)
-      `,
+      `INSERT INTO "User" (id, email, "passwordHash", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4, $5)`,
       [userId, email, hashedPassword, now, now]
     )
 
-    // ④ "Profile" テーブルにプロフィールを作成（名前は任意入力項目のため null になる場合あり）
+    // ④ "Profile" テーブルにプロフィールを作成
     await query(
-      `
-      INSERT INTO "Profile" (
-        id,
-        "userId",
-        name,
-        "createdAt",
-        "updatedAt"
-      )
-      VALUES ($1, $2, $3, $4, $5)
-      `,
+      `INSERT INTO "Profile" (id, "userId", name, "createdAt", "updatedAt") VALUES ($1, $2, $3, $4, $5)`,
       [randomUUID(), userId, name ?? null, now, now]
     )
-
-    console.log('🟢 user created')
-
-    // ⑤ 登録成功後、そのまま自動的にログイン状態にする
-    await signIn('credentials', {
-      email,
-      password,
-      redirect: false,
-    })
-
-    // ⑥ ログイン完了後、一覧（/shops）ページへリダイレクトする
-    redirect('/shops')
-  } catch (error) {
-    console.error('🔴 signUp error', error)
-    throw error
+  } catch {
+    return { success: false, error: '登録に失敗しました' }
   }
+
+  console.log('🟢 user created')
+
+  // ⑤ 登録成功後、自動ログイン
+  await signIn('credentials', { email, password, redirect: false })
+
+  // ⑥ ログイン完了後、一覧ページへリダイレクト
+  redirect('/shops')
 }

--- a/frontend/src/app/actions/update-shop-status.ts
+++ b/frontend/src/app/actions/update-shop-status.ts
@@ -4,24 +4,30 @@ import { prisma } from '@/lib/prisma'
 import { auth } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
 import type { ShopStatus } from '@/types/shop'
+import type { ActionResult } from '@/lib/action-result'
 
 // お店のステータス（WANT / VISITED / FAVORITE）を更新するServer Action
 export async function updateShopStatus(
   shopId: string,
   status: ShopStatus
-): Promise<void> {
+): Promise<ActionResult> {
   const session = await auth()
-  if (!session?.user?.id) throw new Error('Unauthorized')
+  if (!session?.user?.id) return { success: false, error: '認証が必要です' }
   const userId = session.user.id
 
-  await prisma.userShop.update({
-    where: { userId_shopId: { userId, shopId } },
-    data: {
-      status,
-      // VISITED または FAVORITE の場合は訪問日時を現在時刻にセット、WANT に戻す場合はクリア
-      visitedAt: status === 'VISITED' || status === 'FAVORITE' ? new Date() : null,
-    },
-  })
+  try {
+    await prisma.userShop.update({
+      where: { userId_shopId: { userId, shopId } },
+      data: {
+        status,
+        // VISITED または FAVORITE の場合は訪問日時を現在時刻にセット、WANT に戻す場合はクリア
+        visitedAt: status === 'VISITED' || status === 'FAVORITE' ? new Date() : null,
+      },
+    })
 
-  revalidatePath(`/shops/${shopId}`)
+    revalidatePath(`/shops/${shopId}`)
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: 'ステータスの更新に失敗しました' }
+  }
 }

--- a/frontend/src/app/shops/[id]/_components/EditShopDialog.tsx
+++ b/frontend/src/app/shops/[id]/_components/EditShopDialog.tsx
@@ -79,12 +79,13 @@ export function EditShopDialog({
     const handleDelete = async () => {
         if (!window.confirm('このお店を削除してもよろしいですか？')) return
         startTransition(async () => {
-            try {
-                await deleteShop(shopId)
-                // 削除後のリダイレクトやメッセージは deleteShop 内で行うか、もしくはコンポーネント側で行う
-                // deleteShop() 内部で redirect() しているため通常は遷移する
-            } catch (err) {
-                setError('削除に失敗しました')
+            const result = await deleteShop(shopId)
+            if (result.success) {
+                toast.success('お店を削除しました')
+                setIsOpen(false)
+                router.push('/shops')
+            } else {
+                toast.error(result.error)
             }
         })
     }

--- a/frontend/src/app/shops/_components/ShopStatusAction.tsx
+++ b/frontend/src/app/shops/_components/ShopStatusAction.tsx
@@ -1,8 +1,15 @@
 'use client'
 
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { updateShopStatus } from '@/app/actions/update-shop-status'
 import type { ShopStatus } from '@/types/shop'
+
+const STATUS_LABELS: Record<ShopStatus, string> = {
+  WANT: '行きたい',
+  VISITED: '行った',
+  FAVORITE: 'お気に入り',
+}
 
 // お店詳細画面の下部に固定され、お店のステータス（行きたい/行った/お気に入り）を変更するアクションバー
 export function ShopStatusAction({
@@ -18,9 +25,15 @@ export function ShopStatusAction({
   // 選択された新しいステータスをDBに保存し、モーダルを閉じる
   async function handleChange(next: ShopStatus) {
     setLoading(true)
-    await updateShopStatus(shopId, next)
+    const result = await updateShopStatus(shopId, next)
     setLoading(false)
     setOpen(false)
+
+    if (result.success) {
+      toast.success(`「${STATUS_LABELS[next]}」に変更しました`)
+    } else {
+      toast.error(result.error)
+    }
   }
 
   return (

--- a/frontend/src/app/shops/new/_components/CreateShopForm.tsx
+++ b/frontend/src/app/shops/new/_components/CreateShopForm.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useActionState } from 'react'
+import { createShop } from '@/app/actions/create-shop'
+import { TagInput } from '../../_components/TagInput'
+import { PlaceSearchInput } from './PlaceSearchInput'
+
+export function CreateShopForm() {
+    const [state, formAction, isPending] = useActionState(createShop, null)
+
+    return (
+        <form action={formAction} className="space-y-5 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-black/5">
+            {state && !state.success && (
+                <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+                    {state.error}
+                </p>
+            )}
+
+            <div>
+                <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
+                    店名 <span className="text-red-500">*</span>
+                </label>
+                <PlaceSearchInput />
+            </div>
+
+            <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                    タグ
+                </label>
+                <TagInput />
+            </div>
+
+            <div>
+                <label htmlFor="photos" className="mb-1 block text-sm font-medium text-gray-700">
+                    写真
+                </label>
+                <input
+                    type="file"
+                    id="photos"
+                    name="photos"
+                    accept="image/*"
+                    multiple
+                    className="w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-[#e6efe6] file:px-4 file:py-2 file:text-sm file:font-medium file:text-[#4f6f4f] hover:file:bg-[#d8e4d8]"
+                />
+            </div>
+
+            <div>
+                <label htmlFor="memo" className="mb-1 block text-sm font-medium text-gray-700">
+                    メモ
+                </label>
+                <textarea
+                    id="memo"
+                    name="memo"
+                    rows={4}
+                    className="w-full rounded-md border-gray-300 bg-gray-50 px-3 py-2 outline-none ring-1 ring-inset ring-gray-300 focus:bg-white focus:ring-2 focus:ring-[#8fae8f]"
+                    placeholder="気になるメニューなど"
+                />
+            </div>
+
+            <button
+                type="submit"
+                disabled={isPending}
+                className="w-full rounded-full bg-[#8fae8f] py-3 font-medium text-white transition hover:bg-[#7b997b] disabled:opacity-50"
+            >
+                {isPending ? '登録中...' : '登録する'}
+            </button>
+        </form>
+    )
+}

--- a/frontend/src/app/shops/new/_components/ManualShopForm.tsx
+++ b/frontend/src/app/shops/new/_components/ManualShopForm.tsx
@@ -1,16 +1,23 @@
 'use client'
 
+import { useActionState } from 'react'
 import { createManualShop } from '@/app/actions/create-manual-shop'
 import { TagInput } from '../../_components/TagInput'
 
 export function ManualShopForm() {
-    // フォーム送信時は Server Action (createManualShop) に直接 request を渡す
-    // React 18の useTransition を使用すると redirect 時にエラーや意図しない挙動になるためアクションのみ指定
+    const [state, formAction, isPending] = useActionState(createManualShop, null)
+
     return (
         <form
-            action={createManualShop}
+            action={formAction}
             className="space-y-5 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-black/5"
         >
+            {state && !state.success && (
+                <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+                    {state.error}
+                </p>
+            )}
+
             {/* 店名 (必須) */}
             <div>
                 <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
@@ -46,7 +53,6 @@ export function ManualShopForm() {
                 <label className="mb-1 block text-sm font-medium text-gray-700">
                     タグ
                 </label>
-                {/* 既存のTagInputを再利用。内部で name="tags[]" の hidden inputを生成する想定 */}
                 <TagInput />
             </div>
 
@@ -66,9 +72,10 @@ export function ManualShopForm() {
 
             <button
                 type="submit"
+                disabled={isPending}
                 className="w-full rounded-full bg-[#8fae8f] py-3 font-medium text-white transition hover:bg-[#7b997b] disabled:opacity-50"
             >
-                登録する
+                {isPending ? '登録中...' : '登録する'}
             </button>
         </form>
     )

--- a/frontend/src/app/shops/new/page.tsx
+++ b/frontend/src/app/shops/new/page.tsx
@@ -3,9 +3,7 @@ export const dynamic = 'force-dynamic'
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { AppLayout } from '@/components/layout/AppLayout'
-import { createShop } from '@/app/actions/create-shop'
-import { TagInput } from '../_components/TagInput'
-import { PlaceSearchInput } from './_components/PlaceSearchInput'
+import { CreateShopForm } from './_components/CreateShopForm'
 import { ManualShopForm } from './_components/ManualShopForm'
 
 // お店登録ページ (Server Component)
@@ -35,55 +33,7 @@ export default async function NewShopPage({
                     {mode === 'manual' ? (
                         <ManualShopForm />
                     ) : (
-                        <form action={createShop} className="space-y-5 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-black/5">
-                            <div>
-                                <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
-                                    店名 <span className="text-red-500">*</span>
-                                </label>
-                                <PlaceSearchInput />
-                            </div>
-
-                            <div>
-                                <label className="mb-1 block text-sm font-medium text-gray-700">
-                                    タグ
-                                </label>
-                                <TagInput />
-                            </div>
-
-                            <div>
-                                <label htmlFor="photos" className="mb-1 block text-sm font-medium text-gray-700">
-                                    写真
-                                </label>
-                                <input
-                                    type="file"
-                                    id="photos"
-                                    name="photos"
-                                    accept="image/*"
-                                    multiple
-                                    className="w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-[#e6efe6] file:px-4 file:py-2 file:text-sm file:font-medium file:text-[#4f6f4f] hover:file:bg-[#d8e4d8]"
-                                />
-                            </div>
-
-                            <div>
-                                <label htmlFor="memo" className="mb-1 block text-sm font-medium text-gray-700">
-                                    メモ
-                                </label>
-                                <textarea
-                                    id="memo"
-                                    name="memo"
-                                    rows={4}
-                                    className="w-full rounded-md border-gray-300 bg-gray-50 px-3 py-2 outline-none ring-1 ring-inset ring-gray-300 focus:bg-white focus:ring-2 focus:ring-[#8fae8f]"
-                                    placeholder="気になるメニューなど"
-                                />
-                            </div>
-
-                            <button
-                                type="submit"
-                                className="w-full rounded-full bg-[#8fae8f] py-3 font-medium text-white transition hover:bg-[#7b997b]"
-                            >
-                                登録する
-                            </button>
-                        </form>
+                        <CreateShopForm />
                     )}
                 </div>
             </main>

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -34,19 +34,16 @@ export default function SignupPage() {
 
     try {
       setLoading(true)
-      // Server Actionの signUp 関数を呼び出してDBに登録＆自動ログイン
-      await signUp({
-        email,
-        password,
-      })
-      // 成功時、signUp 側で redirect(/shops) が実行されるためここには来ない
-    } catch (err) {
-      const message = err instanceof Error ? err.message : ''
-      if (message === 'USER_ALREADY_EXISTS') {
-        setError('このメールアドレスは既に登録されています')
-      } else {
-        setError('登録に失敗しました。')
+      const result = await signUp({ email, password })
+      // 成功時は signUp 内で redirect('/shops') が実行されるためここには来ない
+      // 失敗時は ActionResult が返る
+      if (!result.success) {
+        setError(result.error)
+        return
       }
+    } catch (err) {
+      // signUp が ActionResult を返すようになったため、ここに来るのはネットワーク障害等
+      setError('登録に失敗しました。')
     } finally {
       // 失敗時などにローディング状態を解除
       setLoading(false)

--- a/frontend/src/lib/action-result.ts
+++ b/frontend/src/lib/action-result.ts
@@ -1,0 +1,3 @@
+export type ActionResult<T = void> =
+    | { success: true; data: T }
+    | { success: false; error: string }


### PR DESCRIPTION
## 概要
issue #18 の対応。Server Action の戻り値形式を統一し、Sonner Toast によるフィードバックを追加。

## 変更内容

### 共通型
- `src/lib/action-result.ts` を新規作成
  ```typescript
  type ActionResult<T = void> =
    | { success: true; data: T }
    | { success: false; error: string }
  ```

### Server Action の統一

| Action | 変更前 | 変更後 |
|---|---|---|
| `update-shop-status` | `throw` / `void` | `ActionResult` |
| `delete-shop` | `throw` + `redirect` | `ActionResult`（redirect はクライアント側へ） |
| `create-shop` | `throw` | `ActionResult`（`useActionState` 対応） |
| `create-manual-shop` | `throw` | `ActionResult`（`useActionState` 対応） |
| `sign-up` | `throw` | `ActionResult` |

### UI フィードバック（Sonner Toast）
- `ShopStatusAction`: ステータス変更成功・失敗時に Toast 表示
- `EditShopDialog`: 削除成功時に Toast + `router.push('/shops')`、失敗時は Toast エラー

### フォームのエラー表示
- `ManualShopForm`: `useActionState` でエラーをインライン表示、ローディング表示を追加
- `CreateShopForm`: 新規コンポーネント（createShop 用、`useActionState` 使用）
- `shops/new/page.tsx`: `CreateShopForm` を使用するよう変更
- `signup/page.tsx`: `ActionResult` 形式に対応

## テスト確認項目
- [ ] ステータス変更時に Toast が表示されること
- [ ] お店削除時に Toast が表示され `/shops` に遷移すること
- [ ] お店登録失敗時にエラーメッセージが表示されること
- [ ] 手動登録失敗時にエラーメッセージが表示されること
- [ ] 登録済みメールでの新規登録時にエラーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)