### PR TITLE
feat: お店登録時にステータスを選択できるようにする

### DIFF
--- a/frontend/src/app/actions/create-manual-shop.ts
+++ b/frontend/src/app/actions/create-manual-shop.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
+import type { ShopStatus } from '@/types/shop'
 import type { ActionResult } from '@/lib/action-result'
 
 export async function createManualShop(
@@ -22,6 +23,15 @@ export async function createManualShop(
 
   if (!name?.trim()) return { success: false, error: '店名を入力してください' }
   if (!address?.trim()) return { success: false, error: '住所を入力してください' }
+
+  // ステータスのバリデーション（未指定または不正値は WANT にフォールバック）
+  const rawStatus = formData.get('status') as string
+  const VALID_STATUSES: ShopStatus[] = ['WANT', 'VISITED', 'FAVORITE']
+  const status: ShopStatus = VALID_STATUSES.includes(rawStatus as ShopStatus)
+    ? (rawStatus as ShopStatus)
+    : 'WANT'
+  // VISITED / FAVORITE の場合は登録時点を訪問日時としてセット
+  const visitedAt = status === 'VISITED' || status === 'FAVORITE' ? new Date() : null
 
   // Google Geocoding API で緯度経度を取得（失敗しても登録は続行）
   let lat: number | null = null
@@ -62,9 +72,9 @@ export async function createManualShop(
         data: { name, address, lat, lng, source: 'manual' },
       })
 
-      // ユーザーとお店を紐づける（初期ステータスは WANT）
+      // ユーザーとお店を紐づける（選択されたステータスで登録、VISITED/FAVORITE は訪問日時もセット）
       await tx.userShop.create({
-        data: { userId, shopId: shop.id, status: 'WANT', memo },
+        data: { userId, shopId: shop.id, status, memo, visitedAt },
       })
 
       // タグを登録（スパム防止のため最大5つまで）

--- a/frontend/src/app/actions/create-shop.ts
+++ b/frontend/src/app/actions/create-shop.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { randomUUID } from 'crypto'
 import { uploadToS3 } from '@/lib/storage.server'
+import type { ShopStatus } from '@/types/shop'
 import type { ActionResult } from '@/lib/action-result'
 
 export async function createShop(
@@ -21,6 +22,15 @@ export async function createShop(
   if (!name?.trim()) return { success: false, error: '店名を入力してください' }
 
   const memo = (formData.get('memo') as string) || null
+  // ステータスのバリデーション（未指定またはと不正値は WANT にフォールバック）
+  const rawStatus = formData.get('status') as string
+  const VALID_STATUSES: ShopStatus[] = ['WANT', 'VISITED', 'FAVORITE']
+  const status: ShopStatus = VALID_STATUSES.includes(rawStatus as ShopStatus)
+    ? (rawStatus as ShopStatus)
+    : 'WANT'
+  // VISITED / FAVORITE の場合は登録時点を訪問日時としてセット
+  const visitedAt = status === 'VISITED' || status === 'FAVORITE' ? new Date() : null
+
   const placeId = (formData.get('placeId') as string) || null
   const address = (formData.get('address') as string) || null
   const lat = formData.get('lat') ? parseFloat(formData.get('lat') as string) : null
@@ -43,9 +53,9 @@ export async function createShop(
         })
       }
 
-      // ユーザーとお店を紐づける（初期ステータスは WANT）
+      // ユーザーとお店を紐づける（選択されたステータスで登録、VISITED/FAVORITE は訪問日時もセット）
       await tx.userShop.create({
-        data: { userId, shopId: shop.id, status: 'WANT', memo },
+        data: { userId, shopId: shop.id, status, memo, visitedAt },
       })
 
       // タグを upsert して ShopTag を登録（Tag.name に @unique があるため upsert 可能）

--- a/frontend/src/app/shops/new/_components/CreateShopForm.tsx
+++ b/frontend/src/app/shops/new/_components/CreateShopForm.tsx
@@ -4,6 +4,7 @@ import { useActionState } from 'react'
 import { createShop } from '@/app/actions/create-shop'
 import { TagInput } from '../../_components/TagInput'
 import { PlaceSearchInput } from './PlaceSearchInput'
+import { StatusRadio } from './StatusRadio'
 
 export function CreateShopForm() {
     const [state, formAction, isPending] = useActionState(createShop, null)
@@ -42,6 +43,13 @@ export function CreateShopForm() {
                     multiple
                     className="w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-[#e6efe6] file:px-4 file:py-2 file:text-sm file:font-medium file:text-[#4f6f4f] hover:file:bg-[#d8e4d8]"
                 />
+            </div>
+
+            <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                    ステータス
+                </label>
+                <StatusRadio />
             </div>
 
             <div>

--- a/frontend/src/app/shops/new/_components/ManualShopForm.tsx
+++ b/frontend/src/app/shops/new/_components/ManualShopForm.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react'
 import { createManualShop } from '@/app/actions/create-manual-shop'
 import { TagInput } from '../../_components/TagInput'
+import { StatusRadio } from './StatusRadio'
 
 export function ManualShopForm() {
     const [state, formAction, isPending] = useActionState(createManualShop, null)
@@ -54,6 +55,14 @@ export function ManualShopForm() {
                     タグ
                 </label>
                 <TagInput />
+            </div>
+
+            {/* ステータス */}
+            <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                    ステータス
+                </label>
+                <StatusRadio />
             </div>
 
             {/* メモ (任意) */}

--- a/frontend/src/app/shops/new/_components/StatusRadio.tsx
+++ b/frontend/src/app/shops/new/_components/StatusRadio.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import type { ShopStatus } from '@/types/shop'
+
+// 選択肢の定義
+const OPTIONS: { value: ShopStatus; label: string }[] = [
+  { value: 'WANT', label: '行きたい' },
+  { value: 'VISITED', label: '行った' },
+  { value: 'FAVORITE', label: 'お気に入り' },
+]
+
+// 登録フォーム用ステータス選択ラジオボタン（デフォルト: WANT）
+export function StatusRadio() {
+  return (
+    <div className="flex gap-2">
+      {OPTIONS.map(({ value, label }) => (
+        <label key={value} className="flex-1 cursor-pointer">
+          <input
+            type="radio"
+            name="status"
+            value={value}
+            defaultChecked={value === 'WANT'}
+            className="peer sr-only"
+          />
+          <span className="block rounded-full border border-gray-300 py-2 text-center text-sm font-medium text-gray-500 transition peer-checked:border-[#8fae8f] peer-checked:bg-[#8fae8f] peer-checked:text-white">
+            {label}
+          </span>
+        </label>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 登録フォームにステータス選択UI（行きたい / 行った / お気に入り）を追加
- `VISITED` / `FAVORITE` で登録した場合、`visitedAt` を登録時点の日時で自動セット
- `CreateShopForm`（Google Places検索）と `ManualShopForm`（手動入力）の両方に対応

## 変更内容
| ファイル | 変更 |
|---|---|
| `StatusRadio.tsx` | 新規作成（ラジオボタン形式、デフォルト: 行きたい） |
| `CreateShopForm.tsx` | StatusRadio を追加 |
| `ManualShopForm.tsx` | StatusRadio を追加 |
| `create-shop.ts` | status・visitedAt をセット |
| `create-manual-shop.ts` | status・visitedAt をセット |

## Test plan
- [ ] 登録フォームでステータス選択UIが表示されることを確認
- [ ] 「行きたい」で登録 → `visitedAt` が null であることを確認
- [ ] 「行った」で登録 → `visitedAt` に登録日時がセットされることを確認
- [ ] 「お気に入り」で登録 → `visitedAt` に登録日時がセットされることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)