### PR TITLE
feat: 各ページの上部中央にタイトルを表示する

### DIFF
--- a/frontend/src/app/favorite/page.tsx
+++ b/frontend/src/app/favorite/page.tsx
@@ -32,6 +32,8 @@ export default async function FavoritePage() {
         </div>
 
         <div className="mx-auto w-full max-w-md space-y-5 sm:max-w-lg md:max-w-2xl lg:max-w-4xl">
+          {/* ページタイトル */}
+          <h1 className="text-center text-2xl font-bold text-gray-900">お気に入り</h1>
 
           {/* 検索入力欄（現状は見た目のみで、今後の実装用） */}
           <div className="rounded-full bg-white px-4 py-3 ring-1 ring-[#8fae8f]/50">

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -21,7 +21,7 @@ export default function MapPage() {
                 </div>
 
                 <div className="mx-auto flex w-full max-w-md flex-1 flex-col sm:max-w-lg md:max-w-2xl lg:max-w-4xl">
-                    <h1 className="mb-4 text-2xl font-bold text-gray-900">マップ</h1>
+                    <h1 className="mb-4 text-center text-2xl font-bold text-gray-900">マップ</h1>
 
                     {/* 
                       マップを配置するコンテナ

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 export default function SettingsPage() {
     return (
         <>
-            <h1 className="mb-8 text-2xl font-bold text-gray-900">設定</h1>
+            <h1 className="mb-8 text-center text-2xl font-bold text-gray-900">設定</h1>
 
             <div className="space-y-8">
                 {/* 各設定グループごとにSettingSectionでまとめる */}

--- a/frontend/src/app/shops/new/page.tsx
+++ b/frontend/src/app/shops/new/page.tsx
@@ -26,7 +26,7 @@ export default async function NewShopPage({
         <AppLayout>
             <main className="min-h-screen px-4 pt-6 pb-24 text-[15px] text-gray-800 sm:px-6 lg:px-10">
                 <div className="mx-auto w-full max-w-md sm:max-w-lg md:max-w-xl">
-                    <h1 className="mb-6 text-xl font-bold">
+                    <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">
                         {mode === 'manual' ? 'お店を手動で登録する' : 'お店を登録する'}
                     </h1>
 

--- a/frontend/src/app/shops/page.tsx
+++ b/frontend/src/app/shops/page.tsx
@@ -30,6 +30,9 @@ export default async function ShopsPage({ searchParams }: Props) {
         </div>
 
         <div className="mx-auto w-full max-w-md space-y-5 sm:max-w-lg md:max-w-2xl lg:max-w-4xl">
+          {/* ページタイトル */}
+          <h1 className="text-center text-2xl font-bold text-gray-900">お店一覧</h1>
+
           {/* 検索欄 */}
           <SearchInput defaultValue={q ?? ''} />
 

--- a/frontend/src/components/settings/SettingsHeader.tsx
+++ b/frontend/src/components/settings/SettingsHeader.tsx
@@ -11,15 +11,15 @@ interface SettingsHeaderProps {
  */
 export function SettingsHeader({ title }: SettingsHeaderProps) {
     return (
-        <div className="mb-8 flex items-center gap-3">
-            {/* 設定トップ画面へ戻るリンク */}
+        <div className="relative mb-8 flex items-center justify-center">
+            {/* 設定トップ画面へ戻るリンク（左端に絶対配置） */}
             <Link
                 href="/settings"
-                className="rounded-full p-2 transition-colors hover:bg-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+                className="absolute left-0 rounded-full p-2 transition-colors hover:bg-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
             >
                 <ChevronLeft className="h-6 w-6 text-gray-600" />
             </Link>
-            {/* 各ページの見出しタイトル */}
+            {/* 各ページの見出しタイトル（中央配置） */}
             <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
         </div>
     )


### PR DESCRIPTION
## Summary

closes #35

- `SettingsHeader` のタイトルを中央揃えに変更（戻るボタンを `absolute left-0` に配置）
- `/shops` にページタイトル「お店一覧」を追加
- `/favorite` にページタイトル「お気に入り」を追加
- `/map` の既存タイトルを `text-center` で中央揃えに変更
- `/settings` の既存タイトルを `text-center` で中央揃えに変更
- `/shops/new` の登録画面タイトルを中央揃えに変更（`text-2xl` に統一）

## Test plan

- [ ] `/shops` でページ上部中央に「お店一覧」が表示される
- [ ] `/favorite` でページ上部中央に「お気に入り」が表示される
- [ ] `/map` でページ上部中央に「マップ」が表示される
- [ ] `/settings` でページ上部中央に「設定」が表示される
- [ ] `/shops/new` でページ上部中央に「お店を登録する」が表示される
- [ ] `/settings/profile` 等の設定サブページでタイトルが中央揃えで表示され、戻るボタンが左端に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)