### PR TITLE
feat: アカウント管理でメールアドレスを変更できるようにする

### DIFF
--- a/frontend/src/app/actions/update-email.ts
+++ b/frontend/src/app/actions/update-email.ts
@@ -1,0 +1,46 @@
+'use server'
+
+import { auth } from '@/lib/auth'
+import { query } from '@/lib/db.server'
+import type { QueryResultRow } from 'pg'
+
+type EmailRow = QueryResultRow & { count: string }
+
+export async function updateEmail(formData: FormData) {
+    const session = await auth()
+    const userId = session?.user?.id
+    if (!userId) return { success: false, error: '認証が必要です' }
+
+    const newEmail = (formData.get('newEmail') as string | null)?.trim()
+
+    // 入力値の検証
+    if (!newEmail) return { success: false, error: '新しいメールアドレスを入力してください' }
+
+    // メールアドレスの形式チェック
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(newEmail)) {
+        return { success: false, error: '正しいメールアドレスの形式で入力してください' }
+    }
+
+    // 現在と同じメールアドレスでないかチェック
+    if (session.user?.email === newEmail) {
+        return { success: false, error: '現在と同じメールアドレスです' }
+    }
+
+    // 重複チェック（他のユーザーが同じメールアドレスを使用していないか）
+    const existing = await query<EmailRow>(
+        `SELECT COUNT(*) as count FROM "User" WHERE email = $1 AND id != $2`,
+        [newEmail, userId]
+    )
+    if (parseInt(existing[0].count) > 0) {
+        return { success: false, error: 'このメールアドレスはすでに使用されています' }
+    }
+
+    // メールアドレスを更新
+    await query(
+        `UPDATE "User" SET email = $1, "updatedAt" = NOW() WHERE id = $2`,
+        [newEmail, userId]
+    )
+
+    return { success: true }
+}

--- a/frontend/src/app/settings/account/_components/EmailChangeForm.tsx
+++ b/frontend/src/app/settings/account/_components/EmailChangeForm.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useTransition } from "react"
+import { toast } from "sonner"
+import { updateEmail } from "@/app/actions/update-email"
+
+interface EmailChangeFormProps {
+    currentEmail: string
+}
+
+export function EmailChangeForm({ currentEmail }: EmailChangeFormProps) {
+    const [isPending, startTransition] = useTransition()
+
+    function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault()
+        const formData = new FormData(e.currentTarget)
+        const form = e.currentTarget
+        startTransition(async () => {
+            const result = await updateEmail(formData)
+            if (result.success) {
+                toast.success("メールアドレスを変更しました。ログアウット後に再ログインすると反映されます。")
+                form.reset()
+            } else {
+                toast.error(result.error ?? "変更に失敗しました")
+            }
+        })
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 現在のメールアドレスを表示（読み取り専用） */}
+            <div className="space-y-2">
+                <label className="text-sm font-semibold text-gray-700">
+                    現在のメールアドレス
+                </label>
+                <p className="rounded-lg border bg-gray-100 px-4 py-2.5 text-[15px] text-gray-500">
+                    {currentEmail}
+                </p>
+            </div>
+
+            {/* 新しいメールアドレス入力欄 */}
+            <div className="space-y-2">
+                <label htmlFor="newEmail" className="text-sm font-semibold text-gray-700">
+                    新しいメールアドレス
+                </label>
+                <input
+                    id="newEmail"
+                    name="newEmail"
+                    type="email"
+                    required
+                    autoComplete="email"
+                    placeholder="example@email.com"
+                    className="w-full rounded-lg border bg-gray-50 px-4 py-2.5 text-[15px] outline-none transition-colors placeholder:text-gray-400 focus:border-[#8fae8f] focus:bg-white focus:ring-1 focus:ring-[#8fae8f]"
+                />
+            </div>
+
+            <button
+                type="submit"
+                disabled={isPending}
+                className="w-full rounded-xl bg-[#8fae8f] py-3 text-[15px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8fae8f] focus-visible:ring-offset-2"
+            >
+                {isPending ? "変更中..." : "メールアドレスを変更する"}
+            </button>
+        </form>
+    )
+}

--- a/frontend/src/app/settings/account/page.tsx
+++ b/frontend/src/app/settings/account/page.tsx
@@ -3,6 +3,7 @@ import { SettingSection } from "@/components/settings/SettingSection"
 import { SettingItem } from "@/components/settings/SettingItem"
 import { SettingsHeader } from "@/components/settings/SettingsHeader"
 import { PasswordChangeForm } from "./_components/PasswordChangeForm"
+import { EmailChangeForm } from "./_components/EmailChangeForm"
 import { DeleteAccountButton } from "./_components/DeleteAccountButton"
 
 export const metadata = {
@@ -18,13 +19,10 @@ export default async function AccountPage() {
             <SettingsHeader title="アカウント管理" />
 
             <div className="space-y-8">
-                <SettingSection title="ログイン情報">
-                    <SettingItem
-                        title="メールアドレス"
-                        rightContent={
-                            <span className="text-[15px] text-gray-500">{email}</span>
-                        }
-                    />
+                <SettingSection title="メールアドレス変更">
+                    <div className="rounded-xl border bg-white p-6 shadow-sm">
+                        <EmailChangeForm currentEmail={email} />
+                    </div>
                 </SettingSection>
 
                 <SettingSection title="パスワード変更">


### PR DESCRIPTION
## Summary

closes #36

- `update-email.ts` Server Action を新規追加
  - 認証チェック → メール形式検証 → 重複チェック → DB更新
- `EmailChangeForm.tsx` Client Component を新規追加
  - 現在のメールアドレス（読み取り専用）＋新しいメールアドレス入力フォーム
- アカウント管理ページに「メールアドレス変更」セクションを追加

> [!NOTE]
> JWT セッションは即座に更新されないため、変更後にログアウット＆再ログインすると新しいメールアドレスが反映されます。その旨をトーストで案内します。

## Test plan

- [ ] `/settings/account` にメールアドレス変更フォームが表示される
- [ ] 現在と同じメールアドレスを入力するとエラーが表示される
- [ ] 不正な形式のメールアドレスを入力するとエラーが表示される
- [ ] 他のユーザーが使用中のメールアドレスを入力するとエラーが表示される
- [ ] 有効な新しいメールアドレスを入力すると成功トーストが表示される
- [ ] 再ログイン後に新しいメールアドレスが反映されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)