### PR TITLE
feat: お問い合わせフォームにデザインをつける

### DIFF
--- a/frontend/src/app/settings/contact/page.tsx
+++ b/frontend/src/app/settings/contact/page.tsx
@@ -1,3 +1,4 @@
+import { Mail } from "lucide-react"
 import { SettingsHeader } from "@/components/settings/SettingsHeader"
 import { ContactForm } from "./_components/ContactForm"
 
@@ -10,6 +11,20 @@ export default function ContactPage() {
         <>
             <SettingsHeader title="お問い合わせ" />
 
+            {/* ヘッダーカード：アイコンと説明文 */}
+            <div className="mb-4 flex items-center gap-4 rounded-xl border bg-white p-5 shadow-sm">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[#8fae8f]/15">
+                    <Mail className="h-6 w-6 text-[#8fae8f]" />
+                </div>
+                <div>
+                    <p className="text-sm font-semibold text-gray-900">お気軽にご連絡ください</p>
+                    <p className="mt-0.5 text-xs leading-relaxed text-gray-500">
+                        ご意見・ご要望・不具合報告など、どんな内容でもお待ちしています。
+                    </p>
+                </div>
+            </div>
+
+            {/* お問い合わせフォーム */}
             <div className="rounded-xl border bg-white p-6 shadow-sm">
                 <ContactForm />
             </div>


### PR DESCRIPTION
## Summary

closes #39

- フォーム上部にヘッダーカードを追加
  - `Mail` アイコン（lucide-react）をグリーン系の丸背景で表示
  - 「お気軽にご連絡ください」の見出しと説明テキストを表示

## Test plan

- [ ] `/settings/contact` を開いてフォームの上にアイコン＋説明テキストのカードが表示されることを確認
- [ ] フォームの送信は引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)