### PR TITLE
fix: プライバシーポリシーの事業者情報欄を削除する

### DIFF
--- a/frontend/src/app/settings/privacy/page.tsx
+++ b/frontend/src/app/settings/privacy/page.tsx
@@ -33,10 +33,6 @@ const sections = [
         heading: "お問い合わせ",
         body: "お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、アプリ内の「お問い合わせ」フォームよりご連絡ください。",
     },
-    {
-        heading: "事業者情報",
-        body: "事業者の氏名: 樋口 大輔\n事業者の住所: 大阪府東大阪市善根寺町3-1-29-103",
-    },
 ]
 
 export default function PrivacyPage() {


### PR DESCRIPTION
## Summary

closes #41

- `sections` 配列から `heading: "事業者情報"`（氏名・住所）の要素を削除

## Test plan

- [ ] `/settings/privacy` を開いて「事業者情報」セクションが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)