### PR TITLE
feat: ログイン・アカウント登録画面にタイトルへ戻るリンクを追加

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { signIn } from 'next-auth/react'
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -39,6 +41,15 @@ export default function LoginPage() {
   return (
     <main className="flex min-h-screen items-center justify-center px-4 sm:px-6">
       <div className="w-full max-w-sm">
+        {/* タイトルへ戻るリンク */}
+        <Link
+          href="/"
+          className="mb-6 flex items-center gap-1 text-sm text-gray-500 transition-colors hover:text-gray-700"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          トップへ戻る
+        </Link>
+
         <h1 className="mb-6 text-center text-2xl font-bold">ログイン</h1>
 
         <form action={handleSubmit} className="space-y-4">

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -52,6 +54,15 @@ export default function SignupPage() {
   return (
     <main className="flex min-h-screen items-center justify-center px-4 sm:px-6">
       <div className="w-full max-w-sm">
+        {/* タイトルへ戻るリンク */}
+        <Link
+          href="/"
+          className="mb-6 flex items-center gap-1 text-sm text-gray-500 transition-colors hover:text-gray-700"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          トップへ戻る
+        </Link>
+
         <h1 className="mb-6 text-center text-2xl font-bold">アカウント登録</h1>
 
         <form className="space-y-4" onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary

closes #48

- ログイン画面（`/login`）のフォーム上部に「← トップへ戻る」リンクを追加
- アカウント登録画面（`/signup`）のフォーム上部に同様のリンクを追加

## Test plan

- [ ] `/login` を開いてフォームの上に「← トップへ戻る」リンクが表示されることを確認
- [ ] クリックすると `/` に遷移することを確認
- [ ] `/signup` でも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)