### PR TITLE
feat: タイトル画面にプライバシーポリシー・利用規約・お問い合わせリンクを追加

### DIFF
--- a/frontend/src/app/actions/send-contact.ts
+++ b/frontend/src/app/actions/send-contact.ts
@@ -4,12 +4,11 @@ import { auth } from '@/lib/auth'
 
 export async function sendContact(formData: FormData) {
     const session = await auth()
-    const userId = session?.user?.id
-    if (!userId) return { success: false, error: '認証が必要です' }
 
     const subject = (formData.get('subject') as string | null)?.trim()
     const message = (formData.get('message') as string | null)?.trim()
-    const senderEmail = session.user?.email ?? ''
+    // 未ログインユーザーの場合は「未ログインユーザー」として送信
+    const senderEmail = session?.user?.email ?? '未ログインユーザー'
 
     if (!subject) return { success: false, error: '件名を入力してください' }
     if (!message) return { success: false, error: '内容を入力してください' }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -64,7 +64,18 @@ export default function TitlePage() {
           </Link>
         </div>
 
-        {/* 法的リンク（#50で追加予定） */}
+        {/* 法的情報・サポートリンク */}
+        <div className="mt-10 flex justify-center gap-5 text-xs text-gray-400">
+          <Link href="/settings/privacy" className="hover:text-gray-600 transition-colors">
+            プライバシーポリシー
+          </Link>
+          <Link href="/settings/terms" className="hover:text-gray-600 transition-colors">
+            利用規約
+          </Link>
+          <Link href="/settings/contact" className="hover:text-gray-600 transition-colors">
+            お問い合わせ
+          </Link>
+        </div>
       </div>
     </main>
   )

--- a/frontend/src/auth.config.ts
+++ b/frontend/src/auth.config.ts
@@ -15,12 +15,24 @@ export const authConfig = {
                 nextUrl.pathname === '/login' ||
                 nextUrl.pathname === '/signup'
 
+            // 未ログインユーザーでも閲覧できる法的情報・サポートページ
+            const isOnGuestPage =
+                nextUrl.pathname === '/settings/privacy' ||
+                nextUrl.pathname === '/settings/terms' ||
+                nextUrl.pathname === '/settings/contact' ||
+                nextUrl.pathname === '/settings/contact/thanks'
+
             if (isOnPublicPage) {
                 // ログイン済みのユーザーが公開ページにアクセスした場合は、一覧（/shops）へリダイレクト
                 if (isLoggedIn) {
                     return Response.redirect(new URL('/shops', nextUrl))
                 }
                 return true // 未ログインならそのまま公開ページへアクセス可能
+            }
+
+            // 法的情報・サポートページは未ログインでもアクセス許可
+            if (isOnGuestPage) {
+                return true
             }
 
             // ログインが必要なページへのアクセスで、未ログインの場合は signIn ページ（/）へリダイレクト


### PR DESCRIPTION
## Summary

closes #50

- `auth.config.ts` に `isOnGuestPage` を追加
  - `/settings/privacy`・`/settings/terms`・`/settings/contact`・`/settings/contact/thanks` を未ログインでもアクセス可能に
- `send-contact.ts` の認証必須チェックを緩和
  - 未ログインユーザーは送信者メールを `'未ログインユーザー'` として送信
- タイトル画面（`/`）下部にリンクを追加
  - プライバシーポリシー・利用規約・お問い合わせ

## Test plan

- [ ] タイトル画面下部にリンクが3つ表示されることを確認
- [ ] 未ログイン状態で各リンクをクリックしてページが表示されることを確認
- [ ] 未ログイン状態でお問い合わせフォームを送信できることを確認
- [ ] ログイン済みの場合も各ページが引き続き正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)