### PR TITLE
fix: 地図用APIにタグと写真URLを追加

### DIFF
--- a/frontend/src/app/api/map/shops/route.ts
+++ b/frontend/src/app/api/map/shops/route.ts
@@ -24,7 +24,23 @@ export async function GET() {
       select: {
         status: true,
         shop: {
-          select: { id: true, name: true, lat: true, lng: true },
+          select: {
+            id: true,
+            name: true,
+            lat: true,
+            lng: true,
+            // タグ情報（最大2件表示用）
+            shopTags: {
+              select: { tag: { select: { name: true } } },
+            },
+            // ユーザーの写真（1枚目のみ）
+            shopPhotos: {
+              where: { userId },
+              orderBy: { createdAt: 'asc' },
+              take: 1,
+              select: { imageUrl: true },
+            },
+          },
         },
       },
     })
@@ -35,6 +51,10 @@ export async function GET() {
       lat: us.shop.lat,
       lng: us.shop.lng,
       status: us.status,
+      // タグ名のみ最大2件
+      tags: us.shop.shopTags.slice(0, 2).map((st) => st.tag.name),
+      // カバー画像URL（なければnull）
+      coverImageUrl: us.shop.shopPhotos[0]?.imageUrl ?? null,
     }))
 
     return NextResponse.json(shops)


### PR DESCRIPTION
## 問題

本番環境でマップのポップアップに写真・タグが表示されない。

## 原因

`/api/map/shops` のレスポンスに `tags` と `coverImageUrl` が含まれていなかった（ローカルに変更があったがコミットされていなかった）。

## 修正

Prisma の select に `shopTags`・`shopPhotos` を追加し、レスポンスに `tags`・`coverImageUrl` を含めるよう修正。

## Test plan

- [ ] 本番環境でピンのポップアップにタグが表示されることを確認
- [ ] 写真があるお店でポップアップに画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)